### PR TITLE
fix: throw mismatch error in run mode

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -21,12 +21,19 @@ it(
   },
 )
 
+// an example test to verify the image diff failures
+// to run:
+//  use "it.only" to run just this test
+//  run with "--spec ..." parameter
+//  run once to create the gold image
+//  then change the page text and run again
+//  it should fail
 it.skip(
   'shows buttons on failure',
   { viewportWidth: 700, viewportHeight: 400 },
   () => {
     cy.get('body')
-      .invoke('html', '<h1>Hello, world 5!</h1>')
+      .invoke('html', '<h1>Hello, world 9!</h1>')
       .invoke('addClass', 'foo')
     cy.imageDiff('buttons on failure')
   },

--- a/src/plugin/setup.ts
+++ b/src/plugin/setup.ts
@@ -13,6 +13,8 @@ type ImageSize = {
   height: number
 }
 
+const label = 'cypress-toy-visual-testing'
+
 function imageSizeDiffer(image1: ImageSize, image2: ImageSize) {
   if (image1.width === image2.width && image1.height === image2.height) {
     return false
@@ -196,8 +198,10 @@ async function diffAnImage(options, config) {
       result.reason = 'Updated gold image'
     }
 
+    console.log('%s: images matched? %s', label, result.match)
     return {
       ...result,
+      match: Boolean(result.match),
       diffImagePath,
       elapsed,
     }

--- a/src/support/commands.ts
+++ b/src/support/commands.ts
@@ -340,13 +340,11 @@ Cypress.Commands.add(
                                   approveButton +
                                   '</div>'
                               }
-                              log
-                                .snapshot('diff image')
-                                .error(
-                                  new Error(
-                                    `image "${name}" did not match the gold image`,
-                                  ),
-                                )
+                              const message = `image "${name}" did not match the gold image`
+                              const error = new Error(message)
+                              log.snapshot('diff image').error(error)
+
+                              throw error
                             })
                         })
                       })


### PR DESCRIPTION
closes #76 

In `cypress run` mode just printing the error to the log was not enough, needed to throw it to fail the test